### PR TITLE
Serialize map types properly

### DIFF
--- a/lib/renderTypeScript.js
+++ b/lib/renderTypeScript.js
@@ -119,7 +119,15 @@ function interfaceOpen(type) {
 // simpleBoltSchema - SimpleBoltSchema
 function render(simpleBoltSchema) {
   let str = '';
-  simpleBoltSchema.types.forEach(type => {
+  simpleBoltSchema.types
+    .filter(type => type.definition.derivedFrom.name === 'Map')
+    .forEach(type => {
+      str += `type ${type.name} = { [id: string]:  ${type.definition.derivedFrom.params[1].name} };
+`;
+  });
+  simpleBoltSchema.types
+    .filter(type => type.definition.derivedFrom.name !== 'Map')
+    .forEach(type => {
     str += interfaceOpen(type);
     str += '\n';
     type.properties.forEach(property => {

--- a/lib/renderTypeScript.js
+++ b/lib/renderTypeScript.js
@@ -122,7 +122,7 @@ function render(simpleBoltSchema) {
   simpleBoltSchema.types
     .filter(type => type.definition.derivedFrom.name === 'Map')
     .forEach(type => {
-      str += `type ${type.name} = { [id: string]:  ${type.definition.derivedFrom.params[1].name} };
+      str += `export type ${type.name} = { [id: string]:  ${type.definition.derivedFrom.params[1].name} };
 `;
   });
   simpleBoltSchema.types


### PR DESCRIPTION
Enables the conversion of
```
type Entries extends Entry[] {}
```

to `type Entries = { [id: string]: Entry };` instead of `interface Entries extends Map<String, Entry>`